### PR TITLE
Removed specific version of required libs

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -13,4 +13,5 @@ platform = atmelavr
 board = megaatmega2560
 framework = arduino
 lib_deps = 
-  AccelStepper@1.58
+  AccelStepper
+


### PR DESCRIPTION
This was causing compile errors when AccelStepper was updated to 1.6x